### PR TITLE
Fix/Editor - Fix font color of editor in dark mode

### DIFF
--- a/admin/src/components/Editor/styles.js
+++ b/admin/src/components/Editor/styles.js
@@ -1,36 +1,41 @@
-import styled from 'styled-components';
-import { Box } from '@strapi/design-system/Box';
+import styled from "styled-components";
+import { Box } from "@strapi/design-system/Box";
 
-/*${({theme}) => console.log(theme.colors)}*/
 export default styled(Box)`
   .menu-bar {
     .is-active {
-      background: ${({theme}) =>  theme.colors.primary200};
-      color: ${({theme}) =>  theme.colors.neutral0};
+      background: ${({ theme }) => theme.colors.primary200};
+      color: ${({ theme }) => theme.colors.neutral0};
     }
 
     .button-group {
-      border: 0.25em solid ${({theme}) =>  theme.colors.neutral100};
+      border: 0.25em solid ${({ theme }) => theme.colors.neutral100};
     }
 
     &.floating {
-      border: 1px solid ${({theme}) =>  theme.colors.neutral200};
-      background: ${({theme}) =>  theme.colors.neutral100};
-      box-shadow: rgba(0, 0, 0, 0.1) 0px 10px 15px -3px, rgba(0, 0, 0, 0.05) 0px 4px 6px -2px;
+      border: 1px solid ${({ theme }) => theme.colors.neutral200};
+      background: ${({ theme }) => theme.colors.neutral100};
+      box-shadow: rgba(0, 0, 0, 0.1) 0px 10px 15px -3px,
+        rgba(0, 0, 0, 0.05) 0px 4px 6px -2px;
     }
   }
 
   .ProseMirror {
     outline: none;
     line-height: 1.25rem;
+    @media (prefers-color-scheme: dark) {
+      color: ${({ theme }) => theme.colors.neutral800};
+    }
+    @media (prefers-color-scheme: light) {
+      color: ${({ theme }) => theme.colors.neutral100};
+    }
 
     > * + * {
       margin-top: 0.75em;
-
     }
 
     .ProseMirror-selectednode {
-      border: 5px solid ${({theme}) =>  theme.colors.primary500};
+      border: 5px solid ${({ theme }) => theme.colors.primary500};
       box-sizing: border-box;
     }
 
@@ -77,7 +82,7 @@ export default styled(Box)`
     }
 
     h3 {
-      font-size: 1.50em;
+      font-size: 1.5em;
     }
 
     h4 {
@@ -99,9 +104,9 @@ export default styled(Box)`
     }
 
     pre {
-      background: #0D0D0D;
-      color: #FFF;
-      font-family: 'JetBrainsMono', monospace;
+      background: #0d0d0d;
+      color: #fff;
+      font-family: "JetBrainsMono", monospace;
       padding: 0.75rem 1rem;
       border-radius: 0.5rem;
 
@@ -121,32 +126,33 @@ export default styled(Box)`
 
     blockquote {
       padding-left: 1rem;
-      border-left: 2px solid rgba(#0D0D0D, 0.1);
+      border-left: 2px solid rgba(#0d0d0d, 0.1);
     }
 
     hr {
       border: 0;
-      border-top: 2px solid rgba(13, 13, 13, .1);
+      border-top: 2px solid rgba(13, 13, 13, 0.1);
       margin: 1rem 0;
     }
 
     table {
       width: 100%;
       table-layout: fixed;
-      border: 1px solid ${({theme}) =>  theme.colors.neutral600};
-      th, td {
-        border: 1px solid ${({theme}) =>  theme.colors.neutral600};
+      border: 1px solid ${({ theme }) => theme.colors.neutral600};
+      th,
+      td {
+        border: 1px solid ${({ theme }) => theme.colors.neutral600};
         padding: ${({ theme }) => theme.spaces[2]};
 
         &.selectedCell {
-          background: ${({theme}) =>  theme.colors.primary500};
+          background: ${({ theme }) => theme.colors.primary500};
         }
       }
 
       th {
-        background: ${({theme}) =>  theme.colors.neutral300};
+        background: ${({ theme }) => theme.colors.neutral300};
         vertical-align: middle;
       }
     }
   }
-`
+`;


### PR DESCRIPTION
Hi, I tried handling this better with the new `useThemeToggle` hook of Strapi, but there seems to be a peerDependency issue when importing this hook from `@strapi/admin` here. Added a simple CSS based workaround.

<img width="634" alt="image" src="https://user-images.githubusercontent.com/16132011/161346994-f1909606-749c-4717-8701-691a7438c2b5.png">
