### PR TITLE
Make sure `settings.other` is defined before accessing `.wordcount`

### DIFF
--- a/admin/src/components/Editor/index.js
+++ b/admin/src/components/Editor/index.js
@@ -183,7 +183,7 @@ const Editor = ({onChange, name, value, editor, disabled, settings}) => {
         </Box>
       </Box>
 
-      { settings.other.wordcount ? (<Box marginTop={'5px'} color="neutral600">
+      { settings.other && settings.other.wordcount ? (<Box marginTop={'5px'} color="neutral600">
         {editor.storage.characterCount.words()} {editor.storage.characterCount.words() > 1 ? 'words' : 'word'}
       </Box>) : null }
 

--- a/admin/src/components/Wysiwyg/index.js
+++ b/admin/src/components/Wysiwyg/index.js
@@ -132,7 +132,7 @@ const WysiwygContent = ({ name, onChange, value, intlLabel, labelAction, disable
       settings.table ? TableCellExtension : null,
       settings.table ? TableHeaderExtension : null,
 
-      settings.other.wordcount ? CharacterCountExtension.configure() : null,
+      settings.other && settings.other.wordcount ? CharacterCountExtension.configure() : null,
 
       // CSS Columns
       CSSColumnsExtension.configure({

--- a/admin/src/pages/HomePage/Tabs/Other.js
+++ b/admin/src/pages/HomePage/Tabs/Other.js
@@ -3,9 +3,10 @@ import {Box} from '@strapi/design-system/Box'
 import {GridLayout} from '@strapi/design-system/Layout'
 import {ToggleInput} from '@strapi/design-system/ToggleInput'
 import {Typography} from '@strapi/design-system/Typography'
-import { addRemoveFromList } from '../../../../../utils/helpers.js'
 
-export default ({errors, values, handleChange, isSubmitting}) => {
+export default ({values, handleChange}) => {
+  const wordcount = values.other && values.others.wordcount;
+
   return (
     <Fragment>
       <Box marginBottom={'1rem'}>
@@ -21,11 +22,11 @@ export default ({errors, values, handleChange, isSubmitting}) => {
             name="other.wordcount"
             onLabel="Enabled"
             offLabel="Disabled"
-            checked={values.other.wordcount}
+            checked={wordcount}
             onChange={e => handleChange({
               target: {
                 name: 'other.wordcount',
-                value: !values.other.wordcount
+                value: !wordcount
               }
             })}/>
         </Box>


### PR DESCRIPTION
I hadn't saved my settings in `/settings/strapi-tiptap-editor`, meaning that `settings.other` was `null`, and therefore it crashed due to trying to read `wordcount` from null.

Fixes #22 