### PR TITLE
fix: update alt in inserted image if media was updated

### DIFF
--- a/admin/src/components/Editor/index.js
+++ b/admin/src/components/Editor/index.js
@@ -134,17 +134,25 @@ const Editor = ({onChange, name, value, editor, disabled, settings}) => {
   const [forceInsert, setForceInsert] = useState(false);
   const handleToggleMediaLib = () => setMediaLibVisible(prev => !prev);
 
+  const getUpdatedImage = (asset) => ({
+    src: asset.url, 
+    alt: asset.alt, 
+    ...(asset.width && {width: asset.width}),
+    ...(asset.height && {height: asset.height}),
+    ...(asset.url?.includes('lazy') || asset.caption === 'lazy' && { loading: 'lazy' }),
+  })
+
   const handleChangeAssets = assets => {
     if (!forceInsert && editor.isActive('image')) {
       assets.map(asset => {
         if (asset.mime.includes('image')) {
-          editor.chain().focus().setImage({src: asset.url}).run()
+          editor.chain().focus().setImage(getUpdatedImage(asset)).run()
         }
       })
     } else {
       assets.map(asset => {
         if (asset.mime.includes('image')) {
-          editor.commands.setImage({src: asset.url, alt: asset.alt})
+          editor.commands.setImage(getUpdatedImage(asset))
         }
       });
     }

--- a/admin/src/components/MediaLib/index.js
+++ b/admin/src/components/MediaLib/index.js
@@ -8,6 +8,7 @@ const MediaLib = ({ isOpen, onChange, onToggle }) => {
 
     const handleSelectAssets = files => {
         const formattedFiles = files.map(f => ({
+            ...f,
             alt: f.alternativeText || f.name,
             url: prefixFileUrlWithBackendUrl(f.url),
             mime: f.mime,

--- a/admin/src/components/Wysiwyg/index.js
+++ b/admin/src/components/Wysiwyg/index.js
@@ -34,6 +34,7 @@ import OrderedListExtension from "@tiptap/extension-ordered-list"
 import BulletListExtension from '@tiptap/extension-bullet-list'
 import ListItemExtension from '@tiptap/extension-list-item'
 import GapcursorExtension from '@tiptap/extension-gapcursor'
+import History from '@tiptap/extension-history'
 import BlockquoteExtension from '@tiptap/extension-blockquote'
 import CodeBlockExtension from '@tiptap/extension-code-block'
 import DocumentExtension from '@tiptap/extension-document'
@@ -159,7 +160,23 @@ const WysiwygContent = ({ name, onChange, value, intlLabel, labelAction, disable
       }) : null,
 
       // Images
-      settings.image.enabled ? ImageExtension.configure({
+      settings.image.enabled ? ImageExtension.extend({
+        addAttributes() {
+          return {
+            ...this.parent?.(),
+            width: { default: null },
+            height: { default: null },
+            loading: { default: null },
+            renderHTML: (attributes) => {
+              return {
+                width: attributes.width,
+                height: attributes.height,
+                loading: attributes.loading
+              };
+            }
+          };
+        }
+      }).configure({
         inline: settings.image.inline,
         allowBase64: settings.image.allowBase64,
       }) : null,
@@ -182,6 +199,7 @@ const WysiwygContent = ({ name, onChange, value, intlLabel, labelAction, disable
       settings.youtube.enabled ? YouTubeExtension.configure({
         inline: false,
       }) : null,
+      History
     ],
     parseOptions: {
       preserveWhitespace: 'full',

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@tiptap/extension-gapcursor": "2.0.0-beta.199",
     "@tiptap/extension-hard-break": "2.0.0-beta.199",
     "@tiptap/extension-heading": "2.0.0-beta.199",
+    "@tiptap/extension-history": "^2.0.0-beta.202",
     "@tiptap/extension-horizontal-rule": "2.0.0-beta.199",
     "@tiptap/extension-image": "2.0.0-beta.199",
     "@tiptap/extension-italic": "2.0.0-beta.199",


### PR DESCRIPTION
Sometimes library doesn't add alt to images. It forces the user to delete and insert the image again. Can we update the alt in inserted images every time the source image is updated?

Also, 
- PR adds width and height to images because without them Lighthouse complains.
- And adds lazyloading feature if the file name contains `lazy` or the caption equals `lazy`.
- Adds History extension

![image](https://user-images.githubusercontent.com/33694447/201636362-ac4259b7-9075-4482-b0cc-0bf227ea2fb1.png)
